### PR TITLE
Whoops; there was a typo. Should have returned true when condition is…

### DIFF
--- a/server/src/main/java/mendhak/teamcity/graphite/BuildStatusListener.java
+++ b/server/src/main/java/mendhak/teamcity/graphite/BuildStatusListener.java
@@ -81,7 +81,7 @@ public class BuildStatusListener
                 break;
 
             Loggers.SERVER.debug("[Graphite] Graphite build feature is enabled.");
-
+            return true;
         }
 
         Loggers.SERVER.debug("[Graphite] Graphite build feature is not enabled.");


### PR DESCRIPTION
… met.